### PR TITLE
Sort files by path when building a pack file

### DIFF
--- a/src/build.rs
+++ b/src/build.rs
@@ -87,14 +87,16 @@ fn write_content<P: Borrow<::PackedFile>>(output_file: &mut File, files: &Vec<P>
 }
 
 pub fn build_pack_from_filesystem(input_directory: &Path, output_file: &mut File, version: ::PFHVersion, bitmask: ::PFHFlags, file_type: ::PFHFileType, pfh_timestamp: u32) -> Result<()> {
-    let input_files = traverse_directory(input_directory, "")?;
-    build_pack_from_memory(&input_files, output_file, version, bitmask, file_type, pfh_timestamp)
+    let mut input_files = traverse_directory(input_directory, "")?;
+    build_pack_from_memory(&mut input_files, output_file, version, bitmask, file_type, pfh_timestamp)
 }
 
-pub fn build_pack_from_memory<P: Borrow<::PackedFile>>(input_files: &Vec<P>, output_file: &mut File, version: ::PFHVersion, bitmask: ::PFHFlags,  file_type: ::PFHFileType, pfh_timestamp: u32) -> Result<()> {
+pub fn build_pack_from_memory<P: Borrow<::PackedFile>>(input_files: &mut Vec<P>, output_file: &mut File, version: ::PFHVersion, bitmask: ::PFHFlags,  file_type: ::PFHFileType, pfh_timestamp: u32) -> Result<()> {
     let mut index_size = 0;
+    input_files.sort_unstable_by(|a, b| a.borrow().path.cmp(&b.borrow().path));
+    let input_files = &*input_files;
     for input_file in input_files {
-        let input_file = input_file.borrow();
+        let input_file: &::PackedFile = input_file.borrow();
         index_size += input_file.path.len() as u32 + 1;
         index_size += 4;
         if bitmask.contains(::PFHFlags::HAS_INDEX_WITH_TIMESTAMPS) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -283,6 +283,6 @@ pub fn build_pack_from_filesystem(input_directory: &Path, output_file: &mut File
     build::build_pack_from_filesystem(input_directory, output_file, version, bitmask, file_type, pfh_timestamp)
 }
 
-pub fn build_pack_from_memory<P: Borrow<PackedFile>>(input: &Vec<P>, output_file: &mut File, version: PFHVersion, bitmask: PFHFlags, file_type: ::PFHFileType, pfh_timestamp: u32) -> Result<()> {
+pub fn build_pack_from_memory<P: Borrow<PackedFile>>(input: &mut Vec<P>, output_file: &mut File, version: PFHVersion, bitmask: PFHFlags, file_type: ::PFHFileType, pfh_timestamp: u32) -> Result<()> {
     build::build_pack_from_memory(input, output_file, version, bitmask, file_type, pfh_timestamp)
 }

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -17,14 +17,14 @@ fn test_repack() {
     fs::copy("tests/twa_boot.pack.bk", "tests/repack_twa_boot.pack").unwrap();
     let f = File::open(Path::new("tests/repack_twa_boot.pack")).expect("file not found");
     let pack = tw_pack_lib::parse_pack(f, true).unwrap();
-    let packed_files: Vec<PackedFile> = pack.into_iter().collect();
+    let mut packed_files: Vec<PackedFile> = pack.into_iter().collect();
 
     for packed_file in &packed_files {
         println!("{:?}", packed_file.get_data().unwrap())
     }
 
     let mut f = File::create(Path::new("tests/repack_twa_boot.pack")).expect("cannot open file");
-    tw_pack_lib::build_pack_from_memory(&packed_files,
+    tw_pack_lib::build_pack_from_memory(&mut packed_files,
         &mut f,
         PFHVersion::PFH5,
         PFHFlags::HAS_BIG_HEADER | PFHFlags::HAS_INDEX_WITH_TIMESTAMPS,


### PR DESCRIPTION
Pros: items are sorted now
Cons: build_pack_* require a mutable vec now

I guess we could sort the files into a new vector if we don't want to require mutable references, but this should™ work for now, since I just copied rpfm's sorting function.